### PR TITLE
Create fallback for removal of callback_url in omniauth-oauth2 dependency.

### DIFF
--- a/lib/omniauth/strategies/launch_pass.rb
+++ b/lib/omniauth/strategies/launch_pass.rb
@@ -20,6 +20,10 @@ module OmniAuth
         raw_info["user"]
       end
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       def setup_phase
         request.env['omniauth.strategy'].options[:authorize_params][:signing_up] =  request.params["signing_up"]
       end


### PR DESCRIPTION
As described [here](https://github.com/intridea/omniauth-oauth2/issues/81), this is (believe it or not!) the simplest fix.